### PR TITLE
test: Disable memory mapping

### DIFF
--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -77,6 +77,10 @@ pub enum Error {
     #[snafu(display("failed to deserialize cluster definition"))]
     DeserializeClusterDefinition {
         // boxed because otherwise Clippy warns about a large enum variant
+        #[snafu(source(from(
+            stackable_operator::kube::core::error_boundary::InvalidObject,
+            Box::new
+        )))]
         source: Box<stackable_operator::kube::core::error_boundary::InvalidObject>,
     },
 
@@ -232,7 +236,6 @@ pub async fn reconcile(
         .0
         .as_ref()
         .map_err(stackable_operator::kube::core::error_boundary::InvalidObject::clone)
-        .map_err(Box::new)
         .context(DeserializeClusterDefinitionSnafu)?;
 
     // dereference (client required)

--- a/tests/templates/kuttl/smoke/10-assert.yaml
+++ b/tests/templates/kuttl/smoke/10-assert.yaml
@@ -340,11 +340,17 @@ metadata:
     app.kubernetes.io/version: 3.0.0
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-cluster-manager
+  ownerReferences:
+  - apiVersion: opensearch.stackable.tech/v1alpha1
+    controller: true
+    kind: OpenSearchCluster
+    name: opensearch
 data:
   opensearch.yml: |-
     cluster.name: "opensearch"
     discovery.type: "zen"
     network.host: "0.0.0.0"
+    node.store.allow_mmap: "false"
     plugins.security.allow_default_init_securityindex: "true"
     plugins.security.nodes_dn: ["CN=generated certificate for pod"]
     plugins.security.ssl.http.enabled: "true"
@@ -368,11 +374,17 @@ metadata:
     app.kubernetes.io/version: 3.0.0
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-data
+  ownerReferences:
+  - apiVersion: opensearch.stackable.tech/v1alpha1
+    controller: true
+    kind: OpenSearchCluster
+    name: opensearch
 data:
   opensearch.yml: |-
     cluster.name: "opensearch"
     discovery.type: "zen"
     network.host: "0.0.0.0"
+    node.store.allow_mmap: "false"
     plugins.security.allow_default_init_securityindex: "true"
     plugins.security.nodes_dn: ["CN=generated certificate for pod"]
     plugins.security.ssl.http.enabled: "true"

--- a/tests/templates/kuttl/smoke/10-install-opensearch.yaml
+++ b/tests/templates/kuttl/smoke/10-install-opensearch.yaml
@@ -53,6 +53,9 @@ spec:
     configOverrides:
       # TODO Add the required options to the operator
       opensearch.yml:
+        # Disable memory mapping in this test; If memory mapping were activated, the kernel setting
+        # vm.max_map_count would have to be increased to 262144 on the node.
+        node.store.allow_mmap: "false"
         # TODO Check that this is safe despite the warning in the documentation
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"


### PR DESCRIPTION
## Description

Disable memory mapping in this test; If memory mapping were activated, the kernel setting `vm.max_map_count` would have to be increased to 262144 on the node.

Part of #2 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
