### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -122,6 +122,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
   - apiGroups:
       - security.openshift.io
     resources:


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.

Intentionally skipping the changelog entry, as this would only bloat a non-released entry