### PR TITLE
feat: Make OPENSEARCH_HOME and OPENSEARCH_PATH_CONF overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
   - PodDisruptionBudgets
   - Replicas
 - Add Listener support ([#17]).
+- Make the environment variables `OPENSEARCH_HOME` and `OPENSEARCH_PATH_CONF` overridable, so that
+  images can be used which have a different directory structure than the Stackable image ([#18]).
 
 [#10]: https://github.com/stackabletech/opensearch-operator/pull/10
 [#17]: https://github.com/stackabletech/opensearch-operator/pull/17
+[#18]: https://github.com/stackabletech/opensearch-operator/pull/18

--- a/docs/modules/opensearch/pages/usage-guide/configuration-environment-overrides.adoc
+++ b/docs/modules/opensearch/pages/usage-guide/configuration-environment-overrides.adoc
@@ -131,7 +131,7 @@ nodes:
     default:
       config: {}
       envOverrides:
-        OPENSEARCH_PATH_CONF: /etc/opensearch
+        OPENSEARCH_HOME: /usr/share/opensearch
 ----
 
 or per role:
@@ -140,11 +140,20 @@ or per role:
 ----
 nodes:
   envOverrides:
-    OPENSEARCH_PATH_CONF: /etc/opensearch
+    OPENSEARCH_HOME: /usr/share/opensearch
   roleGroups:
     default:
       config: {}
 ----
+
+The environment variables `OPENSEARCH_HOME` and `OPENSEARCH_PATH_CONF` are worth mentioning.
+`OPENSEARCH_HOME` contains the path in the image where OpenSearch is installed.
+`OPENSEARCH_PATH_CONF` contains the path with the OpenSearch configuration files.
+They are usually set in the image.
+In the Stackable image, `OPENSEARCH_HOME` is set to `/stackable/opensearch` and `OPENSEARCH_PATH_CONF` to `$\{OPENSEARCH_HOME}/config`.
+The operator must also know the values of these environment variables to mount volumes to the correct paths.
+Since the operator cannot read the values from the image, it assumes the ones from the Stackable image.
+If you use a custom image with different paths, you can override one or both of these environment variables as shown in the example above.
 
 == CLI parameters
 

--- a/rust/operator-binary/src/framework/builder/pod/container.rs
+++ b/rust/operator-binary/src/framework/builder/pod/container.rs
@@ -16,6 +16,22 @@ impl EnvVarSet {
         Self::default()
     }
 
+    pub fn get_env_var(&self, env_var_name: impl Into<EnvVarName>) -> Option<&EnvVar> {
+        self.0.get(&env_var_name.into())
+    }
+
+    pub fn add_env_var(mut self, env_var: EnvVar) -> Self {
+        self.0.insert(env_var.name.clone(), env_var);
+
+        self
+    }
+
+    pub fn merge(mut self, mut env_var_set: EnvVarSet) -> Self {
+        self.0.append(&mut env_var_set.0);
+
+        self
+    }
+
     pub fn with_values<I, K, V>(self, env_vars: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,

--- a/tests/templates/kuttl/external-access/opensearch.yaml.j2
+++ b/tests/templates/kuttl/external-access/opensearch.yaml.j2
@@ -5,7 +5,12 @@ metadata:
   name: opensearch
 spec:
   image:
-    productVersion: 3.1.0
+{% if test_scenario['values']['opensearch'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['opensearch'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['opensearch'].split(',')[0] }}"
+{% else %}
+    productVersion: "{{ test_scenario['values']['opensearch'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   nodes:
     roleGroups:
@@ -57,6 +62,7 @@ spec:
     envOverrides:
       # TODO Make these the defaults in the image
       DISABLE_INSTALL_DEMO_CONFIG: "true"
+      OPENSEARCH_HOME: {{ test_scenario['values']['opensearch_home'] }}
     configOverrides:
       # TODO Add the required options to the operator
       opensearch.yml:
@@ -66,13 +72,13 @@ spec:
         # TODO Check that this is safe despite the warning in the documentation
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"
-        plugins.security.ssl.transport.pemcert_filepath: /stackable/opensearch/config/tls/tls.crt
-        plugins.security.ssl.transport.pemkey_filepath: /stackable/opensearch/config/tls/tls.key
-        plugins.security.ssl.transport.pemtrustedcas_filepath: /stackable/opensearch/config/tls/ca.crt
+        plugins.security.ssl.transport.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt
+        plugins.security.ssl.transport.pemkey_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key
+        plugins.security.ssl.transport.pemtrustedcas_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt
         plugins.security.ssl.http.enabled: "true"
-        plugins.security.ssl.http.pemcert_filepath: /stackable/opensearch/config/tls/tls.crt
-        plugins.security.ssl.http.pemkey_filepath: /stackable/opensearch/config/tls/tls.key
-        plugins.security.ssl.http.pemtrustedcas_filepath: /stackable/opensearch/config/tls/ca.crt
+        plugins.security.ssl.http.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt
+        plugins.security.ssl.http.pemkey_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key
+        plugins.security.ssl.http.pemtrustedcas_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt
         plugins.security.authcz.admin_dn: "CN=generated certificate for pod"
     podOverrides:
       spec:
@@ -80,10 +86,11 @@ spec:
           - name: opensearch
             volumeMounts:
               - name: security-config
-                mountPath: /stackable/opensearch/config/opensearch-security
+                mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/opensearch-security
                 readOnly: true
               - name: tls
-                mountPath: /stackable/opensearch/config/tls
+                # The Java policy allows reading from ${OPENSEARCH_HOME}/config.
+                mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/tls
                 readOnly: true
         securityContext:
           fsGroup: 1000

--- a/tests/templates/kuttl/smoke/10-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-assert.yaml.j2
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/role-group: cluster-manager
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-cluster-manager
   ownerReferences:
@@ -42,7 +42,7 @@ spec:
         app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/role-group: cluster-manager
-        app.kubernetes.io/version: 3.1.0
+        app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
         stackable.tech/opensearch-role.cluster_manager: "true"
         stackable.tech/vendor: Stackable
     spec:
@@ -59,10 +59,12 @@ spec:
             weight: 1
       containers:
       - command:
-        - /stackable/opensearch/opensearch-docker-entrypoint.sh
+        - {{ test_scenario['values']['opensearch_home'] }}/opensearch-docker-entrypoint.sh
         env:
         - name: DISABLE_INSTALL_DEMO_CONFIG
           value: "true"
+        - name: OPENSEARCH_HOME
+          value: {{ test_scenario['values']['opensearch_home'] }}
         - name: cluster.initial_cluster_manager_nodes
           value: opensearch-nodes-cluster-manager-0,opensearch-nodes-cluster-manager-1,opensearch-nodes-cluster-manager-2
         - name: discovery.seed_hosts
@@ -74,7 +76,6 @@ spec:
               fieldPath: metadata.name
         - name: node.roles
           value: cluster_manager
-        image: oci.stackable.tech/sdp/opensearch:3.1.0-stackable0.0.0-dev
         imagePullPolicy: IfNotPresent
         name: opensearch
         ports:
@@ -107,18 +108,18 @@ spec:
             port: http
           timeoutSeconds: 3
         volumeMounts:
-        - mountPath: /stackable/opensearch/config/opensearch.yml
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/opensearch.yml
           name: config
           readOnly: true
           subPath: opensearch.yml
-        - mountPath: /stackable/opensearch/data
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/data
           name: data
         - mountPath: /stackable/listener
           name: listener
-        - mountPath: /stackable/opensearch/config/opensearch-security
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/opensearch-security
           name: security-config
           readOnly: true
-        - mountPath: /stackable/opensearch/config/tls
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/tls
           name: tls
           readOnly: true
       securityContext:
@@ -175,7 +176,7 @@ spec:
         app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/role-group: cluster-manager
-        app.kubernetes.io/version: 3.1.0
+        app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
         stackable.tech/vendor: Stackable
       name: listener
     spec:
@@ -201,7 +202,7 @@ metadata:
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/role-group: data
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-data
   ownerReferences:
@@ -227,7 +228,7 @@ spec:
         app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/role-group: data
-        app.kubernetes.io/version: 3.1.0
+        app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
         stackable.tech/opensearch-role.data: "true"
         stackable.tech/opensearch-role.ingest: "true"
         stackable.tech/opensearch-role.remote_cluster_client: "true"
@@ -246,10 +247,12 @@ spec:
             weight: 1
       containers:
       - command:
-        - /stackable/opensearch/opensearch-docker-entrypoint.sh
+        - {{ test_scenario['values']['opensearch_home'] }}/opensearch-docker-entrypoint.sh
         env:
         - name: DISABLE_INSTALL_DEMO_CONFIG
           value: "true"
+        - name: OPENSEARCH_HOME
+          value: {{ test_scenario['values']['opensearch_home'] }}
         - name: cluster.initial_cluster_manager_nodes
         - name: discovery.seed_hosts
           value: opensearch
@@ -260,7 +263,6 @@ spec:
               fieldPath: metadata.name
         - name: node.roles
           value: ingest,data,remote_cluster_client
-        image: oci.stackable.tech/sdp/opensearch:3.1.0-stackable0.0.0-dev
         imagePullPolicy: IfNotPresent
         name: opensearch
         ports:
@@ -293,18 +295,18 @@ spec:
             port: http
           timeoutSeconds: 3
         volumeMounts:
-        - mountPath: /stackable/opensearch/config/opensearch.yml
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/opensearch.yml
           name: config
           readOnly: true
           subPath: opensearch.yml
-        - mountPath: /stackable/opensearch/data
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/data
           name: data
         - mountPath: /stackable/listener
           name: listener
-        - mountPath: /stackable/opensearch/config/opensearch-security
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/opensearch-security
           name: security-config
           readOnly: true
-        - mountPath: /stackable/opensearch/config/tls
+        - mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/tls
           name: tls
           readOnly: true
       securityContext:
@@ -361,7 +363,7 @@ spec:
         app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/role-group: data
-        app.kubernetes.io/version: 3.1.0
+        app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
         stackable.tech/vendor: Stackable
       name: listener
     spec:
@@ -387,7 +389,7 @@ metadata:
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/role-group: cluster-manager
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-cluster-manager
   ownerReferences:
@@ -405,13 +407,13 @@ data:
     plugins.security.authcz.admin_dn: "CN=generated certificate for pod"
     plugins.security.nodes_dn: ["CN=generated certificate for pod"]
     plugins.security.ssl.http.enabled: "true"
-    plugins.security.ssl.http.pemcert_filepath: "/stackable/opensearch/config/tls/tls.crt"
-    plugins.security.ssl.http.pemkey_filepath: "/stackable/opensearch/config/tls/tls.key"
-    plugins.security.ssl.http.pemtrustedcas_filepath: "/stackable/opensearch/config/tls/ca.crt"
+    plugins.security.ssl.http.pemcert_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt"
+    plugins.security.ssl.http.pemkey_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key"
+    plugins.security.ssl.http.pemtrustedcas_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt"
     plugins.security.ssl.transport.enabled: "true"
-    plugins.security.ssl.transport.pemcert_filepath: "/stackable/opensearch/config/tls/tls.crt"
-    plugins.security.ssl.transport.pemkey_filepath: "/stackable/opensearch/config/tls/tls.key"
-    plugins.security.ssl.transport.pemtrustedcas_filepath: "/stackable/opensearch/config/tls/ca.crt"
+    plugins.security.ssl.transport.pemcert_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt"
+    plugins.security.ssl.transport.pemkey_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key"
+    plugins.security.ssl.transport.pemtrustedcas_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -422,7 +424,7 @@ metadata:
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/role-group: data
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-data
   ownerReferences:
@@ -440,13 +442,13 @@ data:
     plugins.security.authcz.admin_dn: "CN=generated certificate for pod"
     plugins.security.nodes_dn: ["CN=generated certificate for pod"]
     plugins.security.ssl.http.enabled: "true"
-    plugins.security.ssl.http.pemcert_filepath: "/stackable/opensearch/config/tls/tls.crt"
-    plugins.security.ssl.http.pemkey_filepath: "/stackable/opensearch/config/tls/tls.key"
-    plugins.security.ssl.http.pemtrustedcas_filepath: "/stackable/opensearch/config/tls/ca.crt"
+    plugins.security.ssl.http.pemcert_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt"
+    plugins.security.ssl.http.pemkey_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key"
+    plugins.security.ssl.http.pemtrustedcas_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt"
     plugins.security.ssl.transport.enabled: "true"
-    plugins.security.ssl.transport.pemcert_filepath: "/stackable/opensearch/config/tls/tls.crt"
-    plugins.security.ssl.transport.pemkey_filepath: "/stackable/opensearch/config/tls/tls.key"
-    plugins.security.ssl.transport.pemtrustedcas_filepath: "/stackable/opensearch/config/tls/ca.crt"
+    plugins.security.ssl.transport.pemcert_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt"
+    plugins.security.ssl.transport.pemkey_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key"
+    plugins.security.ssl.transport.pemtrustedcas_filepath: "{{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt"
 ---
 apiVersion: v1
 kind: Service
@@ -457,7 +459,7 @@ metadata:
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/role-group: cluster-manager
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-cluster-manager-headless
 spec:
@@ -487,7 +489,7 @@ metadata:
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/role-group: data
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-nodes-data-headless
 spec:
@@ -516,7 +518,7 @@ metadata:
     app.kubernetes.io/instance: opensearch
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch
   ownerReferences:
@@ -550,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: opensearch
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-serviceaccount
   ownerReferences:
@@ -567,7 +569,7 @@ metadata:
     app.kubernetes.io/instance: opensearch
     app.kubernetes.io/managed-by: opensearch.stackable.tech_opensearchcluster
     app.kubernetes.io/name: opensearch
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: {{ test_scenario['values']['opensearch'].split(',')[0] }}
     stackable.tech/vendor: Stackable
   name: opensearch-rolebinding
   ownerReferences:

--- a/tests/templates/kuttl/smoke/10-install-opensearch.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-opensearch.yaml.j2
@@ -5,7 +5,12 @@ metadata:
   name: opensearch
 spec:
   image:
-    productVersion: 3.1.0
+{% if test_scenario['values']['opensearch'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['opensearch'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['opensearch'].split(',')[0] }}"
+{% else %}
+    productVersion: "{{ test_scenario['values']['opensearch'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   nodes:
     roleGroups:
@@ -52,6 +57,7 @@ spec:
     envOverrides:
       # TODO Make these the defaults in the image
       DISABLE_INSTALL_DEMO_CONFIG: "true"
+      OPENSEARCH_HOME: {{ test_scenario['values']['opensearch_home'] }}
     configOverrides:
       # TODO Add the required options to the operator
       opensearch.yml:
@@ -61,13 +67,13 @@ spec:
         # TODO Check that this is safe despite the warning in the documentation
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"
-        plugins.security.ssl.transport.pemcert_filepath: /stackable/opensearch/config/tls/tls.crt
-        plugins.security.ssl.transport.pemkey_filepath: /stackable/opensearch/config/tls/tls.key
-        plugins.security.ssl.transport.pemtrustedcas_filepath: /stackable/opensearch/config/tls/ca.crt
+        plugins.security.ssl.transport.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt
+        plugins.security.ssl.transport.pemkey_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key
+        plugins.security.ssl.transport.pemtrustedcas_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt
         plugins.security.ssl.http.enabled: "true"
-        plugins.security.ssl.http.pemcert_filepath: /stackable/opensearch/config/tls/tls.crt
-        plugins.security.ssl.http.pemkey_filepath: /stackable/opensearch/config/tls/tls.key
-        plugins.security.ssl.http.pemtrustedcas_filepath: /stackable/opensearch/config/tls/ca.crt
+        plugins.security.ssl.http.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt
+        plugins.security.ssl.http.pemkey_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.key
+        plugins.security.ssl.http.pemtrustedcas_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/ca.crt
         plugins.security.authcz.admin_dn: "CN=generated certificate for pod"
     podOverrides:
       spec:
@@ -75,10 +81,10 @@ spec:
           - name: opensearch
             volumeMounts:
               - name: security-config
-                mountPath: /stackable/opensearch/config/opensearch-security
+                mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/opensearch-security
                 readOnly: true
               - name: tls
-                mountPath: /stackable/opensearch/config/tls
+                mountPath: {{ test_scenario['values']['opensearch_home'] }}/config/tls
                 readOnly: true
         securityContext:
           fsGroup: 1000

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -3,18 +3,28 @@ dimensions:
   - name: opensearch
     values:
       - 3.1.0
+      # To use a custom image, add a comma and the full name after the product version, e.g.:
+      # - 3.1.0,oci.stackable.tech/sandbox/opensearch:3.1.0-stackable0.0.0-dev
+      # - 3.1.0,localhost:5000/sdp/opensearch:3.1.0-stackable0.0.0-dev
+      # - 3.1.0,opensearchproject/opensearch:3.1.0
   - name: openshift
     values:
       - "false"
+  - name: opensearch_home
+    values:
+      - /stackable/opensearch # for the Stackable image
+      # - /usr/share/opensearch # for the official image
 tests:
   - name: smoke
     dimensions:
       - opensearch
       - openshift
+      - opensearch_home
   - name: external-access
     dimensions:
       - opensearch
       - openshift
+      - opensearch_home
 suites:
   - name: nightly
     patch:


### PR DESCRIPTION
## Description

Make `OPENSEARCH_HOME` and `OPENSEARCH_PATH_CONF` overridable

In the early development phase of the operator, it is extremly useful, to be able to use the official product image. On the one hand, different behaviors can be tested, on the other hand, other product versions like OpenSearch 2.x can be tested where no Stackable image exists.

Part of #2 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added

### Reviewer

- [x] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
