### PR TITLE
test: Disable the disk allocation decider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,8 +383,8 @@ jobs:
         run: |
           # Installing helm and yq on ubicloud-standard-8-arm only
           if [ "$(arch)" = "aarch64" ]; then
-            curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+            curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
             sudo apt-get -y update
             sudo apt-get -y install helm
             sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_arm64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq

--- a/tests/templates/kuttl/external-access/opensearch.yaml.j2
+++ b/tests/templates/kuttl/external-access/opensearch.yaml.j2
@@ -70,6 +70,11 @@ spec:
         # Disable memory mapping in this test; If memory mapping were activated, the kernel setting
         # vm.max_map_count would have to be increased to 262144 on the node.
         node.store.allow_mmap: "false"
+        # Disable the disk allocation decider in this test; Otherwise the test depends on the disk
+        # usage of the node and if the relative watermark set in
+        # `cluster.routing.allocation.disk.watermark.high` is reached then the security index could
+        # not be created even if enough disk space would be available.
+        cluster.routing.allocation.disk.threshold_enabled: "false"
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"
         plugins.security.ssl.transport.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt

--- a/tests/templates/kuttl/ldap/21-install-opensearch.yaml.j2
+++ b/tests/templates/kuttl/ldap/21-install-opensearch.yaml.j2
@@ -27,6 +27,11 @@ spec:
         # Disable memory mapping in this test; If memory mapping were activated, the kernel setting
         # vm.max_map_count would have to be increased to 262144 on the node.
         node.store.allow_mmap: "false"
+        # Disable the disk allocation decider in this test; Otherwise the test depends on the disk
+        # usage of the node and if the relative watermark set in
+        # `cluster.routing.allocation.disk.watermark.high` is reached then the security index could
+        # not be created even if enough disk space would be available.
+        cluster.routing.allocation.disk.threshold_enabled: "false"
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"
         plugins.security.ssl.transport.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt

--- a/tests/templates/kuttl/metrics/20-install-opensearch.yaml.j2
+++ b/tests/templates/kuttl/metrics/20-install-opensearch.yaml.j2
@@ -29,6 +29,11 @@ spec:
         # Disable memory mapping in this test; If memory mapping were activated, the kernel setting
         # vm.max_map_count would have to be increased to 262144 on the node.
         node.store.allow_mmap: "false"
+        # Disable the disk allocation decider in this test; Otherwise the test depends on the disk
+        # usage of the node and if the relative watermark set in
+        # `cluster.routing.allocation.disk.watermark.high` is reached then the security index could
+        # not be created even if enough disk space would be available.
+        cluster.routing.allocation.disk.threshold_enabled: "false"
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"
         plugins.security.ssl.transport.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt

--- a/tests/templates/kuttl/smoke/10-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-assert.yaml.j2
@@ -399,6 +399,7 @@ metadata:
 data:
   opensearch.yml: |-
     cluster.name: "opensearch"
+    cluster.routing.allocation.disk.threshold_enabled: "false"
     discovery.type: "zen"
     network.host: "0.0.0.0"
     node.store.allow_mmap: "false"
@@ -433,6 +434,7 @@ metadata:
 data:
   opensearch.yml: |-
     cluster.name: "opensearch"
+    cluster.routing.allocation.disk.threshold_enabled: "false"
     discovery.type: "zen"
     network.host: "0.0.0.0"
     node.store.allow_mmap: "false"

--- a/tests/templates/kuttl/smoke/10-install-opensearch.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-opensearch.yaml.j2
@@ -65,6 +65,11 @@ spec:
         # Disable memory mapping in this test; If memory mapping were activated, the kernel setting
         # vm.max_map_count would have to be increased to 262144 on the node.
         node.store.allow_mmap: "false"
+        # Disable the disk allocation decider in this test; Otherwise the test depends on the disk
+        # usage of the node and if the relative watermark set in
+        # `cluster.routing.allocation.disk.watermark.high` is reached then the security index could
+        # not be created even if enough disk space would be available.
+        cluster.routing.allocation.disk.threshold_enabled: "false"
         plugins.security.allow_default_init_securityindex: "true"
         plugins.security.ssl.transport.enabled: "true"
         plugins.security.ssl.transport.pemcert_filepath: {{ test_scenario['values']['opensearch_home'] }}/config/tls/tls.crt


### PR DESCRIPTION
## Description

Disable the disk allocation decider in the tests

Otherwise the tests depend on the disk usage of the node and if the relative watermark set in `cluster.routing.allocation.disk.watermark.high` is reached then the security index could not be created even if enough disk space would be available:

```
[2025-09-03T15:22:34,713][WARN ][o.o.c.r.a.DiskThresholdMonitor] [opensearch-nodes-cluster-manager-0] high disk watermark [90%] exceeded on [1xEltDMGQsmsMMYUy_nMBA][opensearch-nodes-data-0][/stackable/opensearch/data/nodes/0] free: 134.8gb[7.2%], shards will be relocated away from this node; currently relocating away shards totalling [0] bytes; the node is expected to continue to exceed the high disk watermark when these relocations are complete
```

Part of #2  

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
