### PR TITLE
doc: Add troubleshooting guide

### DIFF
--- a/docs/modules/opensearch/pages/troubleshooting/index.adoc
+++ b/docs/modules/opensearch/pages/troubleshooting/index.adoc
@@ -1,0 +1,38 @@
+= Troubleshooting
+
+== Errors and warnings in the OpenSearch logs
+
+=== SSLHandshakeException: Insufficient buffer remaining for AEAD cipher fragment (2). Needs to be more than tag size (16)
+
+The Stackable image of OpenSearch 3.1 uses OpenJDK 21 which is the latest supported JDK version in OpenSearch 3.1.
+When using TLSv1.3, which is the default, the following warning can appear in the OpenSearch logs:
+
+----
+[WARN ][o.o.h.AbstractHttpServerTransport] [opensearch-nodes-default-0] caught exception while handling client http traffic, closing connection Netty4HttpChannel{localAddress=/...:9200, remoteAddress=/...}
+io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: Insufficient buffer remaining for AEAD cipher fragment (2). Needs to be more than tag size (16)
+----
+
+This means that a TLS connection could not be established.
+Unfortunately, the message does not contain the reason.
+The issue with this message is fixed in JDK 24, see https://bugs.openjdk.org/browse/JDK-8331682[JDK-8331682{external-link-icon}^].
+OpenSearch 3.2, which supports JDK 24, will therefore show a proper message.
+
+To find out the reason in OpenSearch 3.1, you could temporarily use TLSv1.2 which is not affected by this JDK bug:
+
+[source,yaml]
+----
+nodes:
+  configOverrides:
+    opensearch.yml:
+      plugins.security.ssl.http.enabled_protocols: TLSv1.2
+----
+
+Instead of the warning above, an error message is shown, e.g.:
+
+----
+[ERROR][o.o.h.n.s.SecureNetty4HttpServerTransport] [opensearch-nodes-default-0] Exception during establishing a SSL connection: javax.net.ssl.SSLHandshakeException: Received fatal alert: unknown_ca
+javax.net.ssl.SSLHandshakeException: Received fatal alert: unknown_ca
+----
+
+In this case, the OpenSearch client cannot verify the certificate chain because it does not have the CA certificate which is used to sign the OpenSearch node certificate.
+See xref:home:secret-operator:usage.adoc[Usage of the Secret Operator], how to provide the CA certificate to the OpenSearch client and to solve this problem.

--- a/docs/modules/opensearch/partials/nav.adoc
+++ b/docs/modules/opensearch/partials/nav.adoc
@@ -13,6 +13,7 @@
 *** xref:opensearch:usage-guide/operations/pod-placement.adoc[]
 *** xref:opensearch:usage-guide/operations/pod-disruptions.adoc[]
 *** xref:opensearch:usage-guide/operations/graceful-shutdown.adoc[]
+* xref:opensearch:troubleshooting/index.adoc[]
 * xref:opensearch:reference/index.adoc[]
 ** xref:opensearch:reference/crds.adoc[]
 *** {crd-docs}/opensearch.stackable.tech/opensearchcluster/v1alpha1/[OpenSearchCluster {external-link-icon}^]


### PR DESCRIPTION
## Description

Add a troubleshooting guide

The first entry is about the warning 'SSLHandshakeException: Insufficient buffer remaining for AEAD cipher fragment (2). Needs to be more than tag size (16)".

Part of #1 

## Documentation

https://docs.stackable.tech/home/nightly/opensearch/troubleshooting/

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Links to generated (nightly) docs added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
