### PR TITLE
fix: Unit test 'test_validate_ok'

### DIFF
--- a/rust/operator-binary/src/controller/validate.rs
+++ b/rust/operator-binary/src/controller/validate.rs
@@ -270,6 +270,7 @@ mod tests {
 
     use super::{ErrorDiscriminants, validate};
     use crate::{
+        built_info,
         controller::{ContextNames, ValidatedCluster, ValidatedLogging, ValidatedOpenSearchConfig},
         crd::{
             NodeRoles,
@@ -294,9 +295,15 @@ mod tests {
             Some(ValidatedCluster::new(
                 ResolvedProductImage {
                     product_version: "3.1.0".to_owned(),
-                    app_version_label_value: LabelValue::from_str("3.1.0-stackable0.0.0-dev")
-                        .expect("should be a valid label value"),
-                    image: "oci.stackable.tech/sdp/opensearch:3.1.0-stackable0.0.0-dev".to_string(),
+                    app_version_label_value: LabelValue::from_str(&format!(
+                        "3.1.0-stackable{pkg_version}",
+                        pkg_version = built_info::PKG_VERSION
+                    ))
+                    .expect("should be a valid label value"),
+                    image: format!(
+                        "oci.stackable.tech/sdp/opensearch:3.1.0-stackable{pkg_version}",
+                        pkg_version = built_info::PKG_VERSION
+                    ),
                     image_pull_policy: "Always".to_owned(),
                     pull_secrets: None,
                 },


### PR DESCRIPTION
## Description

Fixes the unit test `test_validate_ok` which is broken on branches other than `main`.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
