### PR TITLE
chore: Describe RBAC rules, remove unnecessary rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Document Helm deployed RBAC permissions and remove unnecessary permissions ([#129]).
+
+[#129]: https://github.com/stackabletech/opensearch-operator/pull/129
+
 ## [26.3.0] - 2026-03-16
 
 ## [26.3.0-rc1] - 2026-03-16

--- a/deploy/helm/opensearch-operator/templates/clusterrole-operator.yaml
+++ b/deploy/helm/opensearch-operator/templates/clusterrole-operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -128,22 +129,3 @@ rules:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "operator.name" . }}-clusterrole
-  labels:
-  {{- include "operator.labels" . | nindent 4 }}
-rules:
-{{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
-  # Required on OpenShift to allow the OpenSearch pods to run as a non-root user.
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
-    resourceNames:
-      - nonroot-v2
-    verbs:
-      - use
-{{ end }}

--- a/deploy/helm/opensearch-operator/templates/clusterrole-operator.yaml
+++ b/deploy/helm/opensearch-operator/templates/clusterrole-operator.yaml
@@ -113,7 +113,7 @@ rules:
     verbs:
       - create
       - patch
-  # Primary CRD: watched by Controller::new() and read during reconciliation.
+  # Primary CRD: watched by the controller and read during reconciliation.
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:

--- a/deploy/helm/opensearch-operator/templates/clusterrole-product.yaml
+++ b/deploy/helm/opensearch-operator/templates/clusterrole-product.yaml
@@ -1,0 +1,21 @@
+---
+# Product ClusterRole: bound (via per OpenSearchCluster RoleBinding) to the ServiceAccount that
+# OpenSearch workload pods run as.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "operator.name" . }}-clusterrole
+  labels:
+  {{- include "operator.labels" . | nindent 4 }}
+rules:
+{{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+  # Required on OpenShift to allow the OpenSearch pods to run as a non-root user.
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - nonroot-v2
+    verbs:
+      - use
+{{ end }}

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -86,10 +86,10 @@ rules:
       {{- if .Values.maintenance.customResourceDefinitions.maintain }}
       - create
       - patch
+      {{- end }}
       # Required for startup condition
       - list
       - watch
-      {{- end }}
   # Listeners (stackable-listener-operator CRD) expose OpenSearch endpoints via a
   # cluster-level abstraction. Applied via SSA, tracked for orphan cleanup, watched via .owns().
   # get is also used directly in dereference.rs to fetch the discovery service Listener.

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -158,6 +158,7 @@ rules:
     verbs:
       - create
       - patch
+{{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   # Required on OpenShift: allows OpenSearch pods to run with the nonroot-v2
   # SecurityContextConstraint, which permits running as a non-root UID without a specific
   # seccomp profile.
@@ -169,3 +170,4 @@ rules:
       - nonroot-v2
     verbs:
       - use
+{{ end }}

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
+  # For automatic cluster domain detection: nodes are listed/watched to find a node to
+  # proxy through, and nodes/proxy is used to read kubelet info that contains the cluster domain.
   - apiGroups:
       - ""
     resources:
@@ -12,19 +14,25 @@ rules:
     verbs:
       - list
       - watch
-  # For automatic cluster domain detection
   - apiGroups:
       - ""
     resources:
       - nodes/proxy
     verbs:
       - get
+  # Manage core workload resources created per OpenSearchCluster.
+  # All resources are applied via Server-Side Apply (create + patch) and tracked for
+  # orphan cleanup (list + delete). The controller watches all of these via .owns() (watch).
+  # get is required by the ReconciliationPaused strategy, which calls client.get() instead
+  # of apply_patch() when reconciliation is paused.
+  # update is NOT needed: SSA uses patch (HTTP PATCH), not update (HTTP PUT).
+  # - configmaps: per-rolegroup configuration files mounted into pods
+  # - serviceaccounts: per-rolegroup ServiceAccounts for workload pods
+  # - services: per-rolegroup and discovery Services
   - apiGroups:
       - ""
     resources:
       - configmaps
-      - endpoints
-      - pods
       - serviceaccounts
       - services
     verbs:
@@ -33,8 +41,10 @@ rules:
       - get
       - list
       - patch
-      - update
       - watch
+  # RoleBindings bind the product ClusterRole to each per-rolegroup ServiceAccount so that
+  # workload pods have the permissions they need at runtime.
+  # Applied via SSA, tracked for orphan cleanup, and watched via .owns().
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -45,8 +55,9 @@ rules:
       - get
       - list
       - patch
-      - update
       - watch
+  # StatefulSets drive the OpenSearch node pods.
+  # Applied via SSA, tracked for orphan cleanup, and watched via .owns().
   - apiGroups:
       - apps
     resources:
@@ -57,8 +68,9 @@ rules:
       - get
       - list
       - patch
-      - update
       - watch
+  # PodDisruptionBudgets limit voluntary disruptions during rolling upgrades and maintenance.
+  # Applied via SSA, tracked for orphan cleanup, and watched via .owns().
   - apiGroups:
       - policy
     resources:
@@ -69,7 +81,6 @@ rules:
       - get
       - list
       - patch
-      - update
       - watch
   - apiGroups:
       - apiextensions.k8s.io
@@ -86,17 +97,22 @@ rules:
       - list
       - watch
       {{- end }}
+  # Listeners (stackable-listener-operator CRD) expose OpenSearch endpoints via a
+  # cluster-level abstraction. Applied via SSA, tracked for orphan cleanup, watched via .owns().
+  # get is also used directly in dereference.rs to fetch the discovery service Listener.
   - apiGroups:
       - listeners.stackable.tech
     resources:
       - listeners
     verbs:
-      - get
-      - list
-      - watch
-      - patch
       - create
       - delete
+      - get
+      - list
+      - patch
+      - watch
+  # Events are emitted by the controller to report reconciliation results (e.g. errors,
+  # status changes) visible via kubectl describe / kubectl get events.
   - apiGroups:
       - events.k8s.io
     resources:
@@ -104,6 +120,9 @@ rules:
     verbs:
       - create
       - patch
+  # The primary CRD: the controller watches OpenSearchCluster objects to trigger reconciliation
+  # and reads them during reconcile. patch is NOT needed here — the operator only writes
+  # to the /status subresource (see rule below).
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
@@ -111,14 +130,17 @@ rules:
     verbs:
       - get
       - list
-      - patch
       - watch
+  # Status subresource: the controller calls apply_patch_status() after each reconcile to
+  # update conditions (Available, Degraded, etc.) on the OpenSearchCluster object.
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
+  # The operator creates per-rolegroup RoleBindings that bind the product ClusterRole to
+  # workload ServiceAccounts. bind permission on the product ClusterRole is required for that.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -135,6 +157,10 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
+  # OpenSearch pods need read access to their own namespace resources at runtime:
+  # - configmaps: read configuration (e.g. opensearch.yml, log4j2.properties)
+  # - secrets: read TLS certificates and credentials mounted into the pod
+  # - serviceaccounts: read own ServiceAccount metadata (e.g. for token projection)
   - apiGroups:
       - ""
     resources:
@@ -143,6 +169,7 @@ rules:
       - serviceaccounts
     verbs:
       - get
+  # OpenSearch pods emit Kubernetes Events (e.g. via the Stackable logging framework).
   - apiGroups:
       - events.k8s.io
     resources:
@@ -150,6 +177,9 @@ rules:
     verbs:
       - create
       - patch
+  # Required on OpenShift: allows OpenSearch pods to run with the nonroot-v2
+  # SecurityContextConstraint, which permits running as a non-root UID without a specific
+  # seccomp profile.
   - apiGroups:
       - security.openshift.io
     resources:

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -82,6 +82,8 @@ rules:
       - list
       - patch
       - watch
+  # Required for maintaining the CRDs within the operator (including the conversion webhook info).
+  # Also for the startup condition check before the controller can run.
   - apiGroups:
       - apiextensions.k8s.io
     resources:

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -40,6 +40,15 @@ rules:
       - list
       - patch
       - watch
+  # Required to bind the product ClusterRole to the per-rolegroup ServiceAccount.
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+    resourceNames:
+      - {{ include "operator.name" . }}-clusterrole
   # StatefulSet created per role group. Applied via SSA, tracked for orphan cleanup, and
   # owned by the controller.
   - apiGroups:
@@ -119,15 +128,6 @@ rules:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
-  # Required to bind the product ClusterRole to the per-rolegroup ServiceAccount.
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-    resourceNames:
-      - {{ include "operator.name" . }}-clusterrole
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -13,14 +13,7 @@ rules:
     verbs:
       - get
   # Manage core workload resources created per OpenSearchCluster.
-  # All resources are applied via Server-Side Apply (create + patch) and tracked for
-  # orphan cleanup (list + delete). The controller watches all of these via .owns() (watch).
-  # get is required by the ReconciliationPaused strategy, which calls client.get() instead
-  # of apply_patch() when reconciliation is paused.
-  # update is NOT needed: SSA uses patch (HTTP PATCH), not update (HTTP PUT).
-  # - configmaps: per-rolegroup configuration files mounted into pods
-  # - serviceaccounts: per-rolegroup ServiceAccounts for workload pods
-  # - services: per-rolegroup and discovery Services
+  # Applied via SSA, tracked for orphan cleanup, and owned by the controller.
   - apiGroups:
       - ""
     resources:
@@ -34,9 +27,8 @@ rules:
       - list
       - patch
       - watch
-  # RoleBindings bind the product ClusterRole to each per-rolegroup ServiceAccount so that
-  # workload pods have the permissions they need at runtime.
-  # Applied via SSA, tracked for orphan cleanup, and watched via .owns().
+  # RoleBinding created per role group to bind the product ClusterRole to the workload
+  # ServiceAccount. Applied via SSA, tracked for orphan cleanup, and owned by the controller.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -48,8 +40,8 @@ rules:
       - list
       - patch
       - watch
-  # StatefulSets drive the OpenSearch node pods.
-  # Applied via SSA, tracked for orphan cleanup, and watched via .owns().
+  # StatefulSet created per role group. Applied via SSA, tracked for orphan cleanup, and
+  # owned by the controller.
   - apiGroups:
       - apps
     resources:
@@ -61,8 +53,8 @@ rules:
       - list
       - patch
       - watch
-  # PodDisruptionBudgets limit voluntary disruptions during rolling upgrades and maintenance.
-  # Applied via SSA, tracked for orphan cleanup, and watched via .owns().
+  # PodDisruptionBudget created per role group. Applied via SSA, tracked for orphan cleanup,
+  # and owned by the controller.
   - apiGroups:
       - policy
     resources:
@@ -90,9 +82,8 @@ rules:
       # Required for startup condition
       - list
       - watch
-  # Listeners (stackable-listener-operator CRD) expose OpenSearch endpoints via a
-  # cluster-level abstraction. Applied via SSA, tracked for orphan cleanup, watched via .owns().
-  # get is also used directly in dereference.rs to fetch the discovery service Listener.
+  # Listener created per role group for external access. Applied via SSA, tracked for orphan
+  # cleanup, and owned by the controller.
   - apiGroups:
       - listeners.stackable.tech
     resources:
@@ -104,8 +95,7 @@ rules:
       - list
       - patch
       - watch
-  # Events are emitted by the controller to report reconciliation results (e.g. errors,
-  # status changes) visible via kubectl describe / kubectl get events.
+  # Required to report reconciliation results and warnings back to the OpenSearchCluster object.
   - apiGroups:
       - events.k8s.io
     resources:
@@ -113,9 +103,7 @@ rules:
     verbs:
       - create
       - patch
-  # The primary CRD: the controller watches OpenSearchCluster objects to trigger reconciliation
-  # and reads them during reconcile. patch is NOT needed here — the operator only writes
-  # to the /status subresource (see rule below).
+  # Primary CRD: watched by Controller::new() and read during reconciliation.
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
@@ -124,16 +112,14 @@ rules:
       - get
       - list
       - watch
-  # Status subresource: the controller calls apply_patch_status() after each reconcile to
-  # update conditions (Available, Degraded, etc.) on the OpenSearchCluster object.
+  # Status subresource: updated at the end of every reconciliation.
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
-  # The operator creates per-rolegroup RoleBindings that bind the product ClusterRole to
-  # workload ServiceAccounts. bind permission on the product ClusterRole is required for that.
+  # Required to bind the product ClusterRole to the per-rolegroup ServiceAccount.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -150,7 +136,7 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  # OpenSearch pods emit Kubernetes Events (e.g. via the Stackable logging framework).
+  # Allows OpenSearch pods to emit Kubernetes events.
   - apiGroups:
       - events.k8s.io
     resources:
@@ -159,9 +145,7 @@ rules:
       - create
       - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
-  # Required on OpenShift: allows OpenSearch pods to run with the nonroot-v2
-  # SecurityContextConstraint, which permits running as a non-root UID without a specific
-  # seccomp profile.
+  # Required on OpenShift to allow the OpenSearch pods to run as a non-root user.
   - apiGroups:
       - security.openshift.io
     resources:

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -150,18 +150,6 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  # OpenSearch pods need read access to their own namespace resources at runtime:
-  # - configmaps: read configuration (e.g. opensearch.yml, log4j2.properties)
-  # - secrets: read TLS certificates and credentials mounted into the pod
-  # - serviceaccounts: read own ServiceAccount metadata (e.g. for token projection)
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - secrets
-      - serviceaccounts
-    verbs:
-      - get
   # OpenSearch pods emit Kubernetes Events (e.g. via the Stackable logging framework).
   - apiGroups:
       - events.k8s.io

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -136,14 +136,6 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  # Allows OpenSearch pods to emit Kubernetes events.
-  - apiGroups:
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   # Required on OpenShift to allow the OpenSearch pods to run as a non-root user.
   - apiGroups:

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -89,7 +89,6 @@ rules:
     resources:
       - customresourcedefinitions
     verbs:
-      - get
       # Required to maintain the CRD. The operator needs to do this, as it needs to enter e.g. it's
       # generated certificate in the conversion webhook.
       {{- if .Values.maintenance.customResourceDefinitions.maintain }}

--- a/deploy/helm/opensearch-operator/templates/roles.yaml
+++ b/deploy/helm/opensearch-operator/templates/roles.yaml
@@ -5,15 +5,7 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  # For automatic cluster domain detection: nodes are listed/watched to find a node to
-  # proxy through, and nodes/proxy is used to read kubelet info that contains the cluster domain.
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - list
-      - watch
+  # For automatic cluster domain detection.
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/798

> [!NOTE]
> This was initially generated by a coding assistant to see how well it can inspect code and _review the RBAC rules_. the changes will be properly checked before reviews are requested.

- [x] Document each rule
- [x] Check the docs make sense. Rewrite where necessary
- [x] Remove unnecessary permissions
- [x] Attach explanations to PR description
- [x] Run all tests
- [x] Split operator and product roles into separate files

## Removed permissions (operator role)

| Resource | Verb(s) removed | Reason |
|---|---|---|
| `endpoints` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Never managed by the operator. Kubernetes auto-creates Endpoints for Services; the operator never creates Endpoints objects directly. |
| `pods` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Never managed directly. StatefulSets implicitly create pods — the operator only creates the StatefulSet. |
| `configmaps` | `update` | `client.update()` (HTTP PUT) is never called. All writes use `client.apply_patch()` (SSA = HTTP PATCH). |
| `serviceaccounts` |`update` | Same reason as above. |
| `services` | `update` | Same reason as above. |
| `rolebindings` | `update` | Same reason as above. |
| `statefulsets` | `update` | Same reason as above. |
| `poddisruptionbudgets` | `update` | Same reason as above. |
| `opensearchclusters` | `patch` | The operator never SSA-patches the primary CRD object. The spec is user-owned; only the status subresource is written (covered by the separate `opensearchclusters/status` rule). |
| `nodes` | `list`, `watch` | Not used for cluster domain lookup |
| `customresourcedefinitions` | `get` | Not needed for CRD maintenance |

## Removed permissions (product role)

| Resource | Verb(s) removed | Reason |
|---|---|---|
| `events` | `create`, `patch` | The operator manages events, not the product |
| `configmaps`, `secrets`, `serviceaccounts` | `get` | Not used, appears to be from copy/paste |